### PR TITLE
Removes obfuscating error handling when emitting messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,14 +212,7 @@ PythonShell.prototype.receive = function (data) {
     this._remaining = lastLine;
 
     parts.forEach(function (part) {
-        try {
-            self.emit('message', self.parser(part));
-        } catch(err) {
-            self.emit('error', extend(
-                new Error('invalid message: ' + data + ' >> ' + err),
-                { inner: err, data: part}
-            ));
-        }
+        self.emit('message', self.parser(part));
     });
 
     return this;


### PR DESCRIPTION
Fixes https://github.com/extrabacon/python-shell/issues/19, which has a longer discussion about the issue itself. 

Again, I totally understand if there's some use case that I'm missing that this PR would mess with.