### PR TITLE
Python working directory setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Creates an instance of `PythonShell` and starts the Python process
   * `encoding`: the text encoding to apply on the child process streams (default: "utf8")
   * `pythonPath`: The path where to locate the "python" executable. Default: "python"
   * `pythonOptions`: Array of option switches to pass to "python"
-  * `scriptPath`: The default path where to look for scripts. Default is the current working directory.
+  * `scriptPath`: The default path where to look for scripts. Default is the current working directory. And if you set the scriptPath, the python working directory will be set to this path.
   * `args`: Array of arguments to pass to the script
 
 Other options are forwarded to `child_process.spawn`.

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ var PythonShell = function (script, options) {
     var errorData = '';
     EventEmitter.call(this);
 
-    options = extend({}, PythonShell.defaultOptions, options);
+    options = extend({}, PythonShell.defaultOptions, options,{cwd: options.scriptPath || './'});
     var pythonPath = options.pythonPath || 'python';
     var pythonOptions = toArray(options.pythonOptions);
     var scriptArgs = toArray(options.args);
@@ -56,6 +56,7 @@ var PythonShell = function (script, options) {
     this.formatter = resolve('format', options.formatter || this.mode);
     this.parser = resolve('parse', options.parser || this.mode);
     this.terminated = false;
+
     this.childProcess = spawn(pythonPath, this.command, options);
 
     ['stdout', 'stdin', 'stderr'].forEach(function (name) {


### PR DESCRIPTION
Hi extrabacon,

Recently I am using your python-shell to build an online python runner. The feature for that runner is to allow user to upload script and data and run it to download the result. The code for that runner is in my github.

But I found an issue that after I set the scriptPath. It is confused that the python working directory is not changed based in the scriptPath. Some of my python scripts will not run as they are. Especially for those who are using relative path to read and write data file.

I understand I can use node child process spawn option to set. But it will be better to set the python working directory follows scriptPath if the scriptPath is set already.  So I changed the code based on my understanding.

Hope this can help you and improve the developer experience to use your amazing python-shell!

Thanks
