### PR TITLE
use python3 binary on unix systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,9 +45,12 @@ var PythonShell = function (script, options) {
     var self = this;
     var errorData = '';
     EventEmitter.call(this);
-
+    
     options = extend({}, PythonShell.defaultOptions, options);
-    var pythonPath = options.pythonPath || 'python';
+    var pythonPath;
+    if (!options.pythonPath) {
+        pythonPath = process.platform != "win32" ? "python3" : "python"
+    } else pythonPath = options.pythonPath;
     var pythonOptions = toArray(options.pythonOptions);
     var scriptArgs = toArray(options.args);
 


### PR DESCRIPTION
I verified it worked in my use case. I was able to successfully omit the pythonPath property, and it used python3 on my macOs system.