### PR TITLE
exported type PythonShellError

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,7 @@ export interface Options extends SpawnOptions{
     args?: string[]
 }
 
-class PythonShellError extends Error{
+export class PythonShellError extends Error{
     traceback: string | Buffer;
     exitCode?:number;
 }


### PR DESCRIPTION
I believe some typescript callbacks such as end(callback: (err: PythonShellError, exitCode: number, exitSignal: string) => any): this; needs the type PythonShellError.