### PR TITLE
Update default python path for windows platform 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,7 @@ export class PythonShell extends EventEmitter{
 
     // starting 2020 python2 is deprecated so we choose 3 as default
     // except for windows which just has "python" command
-    static defaultPythonPath = process.platform != "win32" ? "python3" : "python";
+    static defaultPythonPath = process.platform != "win32" ? "python3" : "py";
 
     static defaultOptions:Options = {}; //allow global overrides for options
     


### PR DESCRIPTION
closes #167 
Python is available as `py` in windows machines by default and not `python` unless explicitly setting it as an environment variable. 

> Exception being thrown:

![image](https://user-images.githubusercontent.com/25279263/50372079-95324b00-05ed-11e9-928d-efa2047996ed.JPG)