### PR TITLE
Honour defaultOptions.pythonPath in checkSyntax

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -244,7 +244,12 @@ export class PythonShell extends EventEmitter{
 	 */
 	static async checkSyntaxFile(filePath:string){
 
-	    let compileCommand = `${this.defaultPythonPath} -m py_compile ${filePath}`
+        let pythonPath:string;
+        if (this.defaultOptions.pythonPath) {
+            pythonPath = this.defaultOptions.pythonPath;
+        } else pythonPath = this.defaultPythonPath;
+
+	    let compileCommand = `${pythonPath} -m py_compile ${filePath}`
 
         return new Promise<string>((resolve, reject) => {
             exec(compileCommand, (error, stdout, stderr) => {

--- a/test/test-python-shell.ts
+++ b/test/test-python-shell.ts
@@ -80,6 +80,15 @@ describe('PythonShell', function () {
                 done();
             })
         })
+
+        it('should honour defaultOptions.pythonPath', function ( done) {
+            PythonShell.defaultOptions = {
+                pythonPath: "/usr/bin/python2.7"
+            };
+            PythonShell.checkSyntax("print 1").then(()=>{
+                done();
+            })
+        })
     })
 
     // #158 these tests are failing on appveyor windows node 8/10 python 2/3


### PR DESCRIPTION
Could we use defaultOptions to set the pythonPath used in checkSyntax (and CheckSyntaxFile) please?