### PR TITLE
Fix README.md examples with mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ Example:
 
 ```typescript
 // send a message in text mode
-let shell = new PythonShell('script.py', { mode: 'text '});
+let shell = new PythonShell('script.py', { mode: 'text'});
 shell.send('hello world!');
 
 // send a message in JSON mode
-let shell = new PythonShell('script.py', { mode: 'json '});
+let shell = new PythonShell('script.py', { mode: 'json'});
 shell.send({ command: "do_stuff", args: [1, 2, 3] });
 ```
 
@@ -294,13 +294,13 @@ Example:
 
 ```typescript
 // receive a message in text mode
-let shell = new PythonShell('script.py', { mode: 'text '});
+let shell = new PythonShell('script.py', { mode: 'text'});
 shell.on('message', function (message) {
   // handle message (a line of text from stdout)
 });
 
 // receive a message in JSON mode
-let shell = new PythonShell('script.py', { mode: 'json '});
+let shell = new PythonShell('script.py', { mode: 'json'});
 shell.on('message', function (message) {
   // handle message (a line of text from stdout, parsed as JSON)
 });
@@ -314,7 +314,7 @@ Example:
 
 ```typescript
 // receive a message in text mode
-let shell = new PythonShell('script.py', { mode: 'text '});
+let shell = new PythonShell('script.py', { mode: 'text'});
 shell.on('stderr', function (stderr) {
   // handle stderr (a line of text from stderr)
 });


### PR DESCRIPTION
the extra space resulted on the parse not being set when I copy pasted one of these

Gave me a `TypeError: self.stderrParser is not a function` error to track down