### PR TITLE
Make stdout available on error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -284,8 +284,7 @@ export class PythonShell extends EventEmitter{
         return pyshell.on('message', function (message) {
             output.push(message);
         }).end(function (err) {
-            if (err) return callback(err);
-            return callback(null, output.length ? output : null);
+            return callback(err? err : null, output.length ? output : null);
         });
     };
 


### PR DESCRIPTION
When the process exits with an error, include the stdout output as well as the error. This makes debugging script failures more straightforward since the rest of the output is available.

For example:

print('hello world')
raise Exception('goodbye world')

callback() will now receive both "goodbye world" error, and the "hello world" output.