### PR TITLE
doc: add typings for events

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -432,3 +432,41 @@ export class PythonShell extends EventEmitter{
         return this.kill(signal)
     }
 };
+
+// This interface is merged in with the above class definition
+export interface PythonShell {
+    addListener(event: string, listener: (...args: any[]) => void): this;
+    emit(event: string | symbol, ...args: any[]): boolean;
+    on(event: string, listener: (...args: any[]) => void): this;
+    once(event: string, listener: (...args: any[]) => void): this;
+    prependListener(event: string, listener: (...args: any[]) => void): this;
+    prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+
+    addListener(event: "message", listener: (parsedChunk: any) => void): this;
+    emit(event: "message", parsedChunk: any): boolean;
+    on(event: "message", listener: (parsedChunk: any) => void): this;
+    once(event: "message", listener: (parsedChunk: any) => void): this;
+    prependListener(event: "message", listener: (parsedChunk: any) => void): this;
+    prependOnceListener(event: "message", listener: (parsedChunk: any) => void): this;
+
+    addListener(event: "stderr", listener: (parsedChunk: any) => void): this;
+    emit(event: "stderr", parsedChunk: any): boolean;
+    on(event: "stderr", listener: (parsedChunk: any) => void): this;
+    once(event: "stderr", listener: (parsedChunk: any) => void): this;
+    prependListener(event: "stderr", listener: (parsedChunk: any) => void): this;
+    prependOnceListener(event: "stderr", listener: (parsedChunk: any) => void): this;
+
+    addListener(event: "close", listener: () => void): this;
+    emit(event: "close", ): boolean;
+    on(event: "close", listener: () => void): this;
+    once(event: "close", listener: () => void): this;
+    prependListener(event: "close", listener: () => void): this;
+    prependOnceListener(event: "close", listener: () => void): this;
+
+    addListener(event: "error", listener: (error: PythonShellError) => void): this;
+    emit(event: "error", error: PythonShellError): boolean;
+    on(event: "error", listener: (error: PythonShellError) => void): this;
+    once(event: "error", listener: (error: PythonShellError) => void): this;
+    prependListener(event: "error", listener: (error: PythonShellError) => void): this;
+    prependOnceListener(event: "error", listener: (error: PythonShellError) => void): this;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "python-shell",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
idk if you need the explanatory comment. see https://stackoverflow.com/a/47671334/490829 and https://www.typescriptlang.org/docs/handbook/declaration-merging.html for a bit more of an explanation

with this change, the `error` variable in the handler will be properly typed as a `PythonShellError`
```ts
import { PythonShell } from 'python-shell';
const pyshell = new PythonShell('path/to/my/script.py')
pyshell.on('error', (error) => console.log(`traceback: ${error.traceback}`))
```