### PR TITLE
Use kill signal's returned value

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -407,8 +407,7 @@ export class PythonShell extends EventEmitter {
      * @returns {PythonShell} The same instance for chaining calls
      */
     kill(signal?: NodeJS.Signals) {
-        this.childProcess.kill(signal);
-        this.terminated = true;
+        this.terminated = this.childProcess.kill(signal);
         return this;
     };
 


### PR DESCRIPTION
On calling kill, set ```terminated``` to the result of ```childProcess.kill()```.
This is useful as you can try a variety of kill signals by checking ```this.terminated``` until it is successfully killed.

I think this is somewhat possible already by listening for an ```error``` event for a failed termination, but this method allows you to loop the kill method without relying on an external callback.