### PR TITLE
Fix runString temp path to use tmpdir() and add regression test

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -371,7 +371,7 @@ export class PythonShell extends EventEmitter {
   static runString(code: string, options?: Options) {
     // put code in temp file
     const randomInt = getRandomInt();
-    const filePath = tmpdir + sep + `pythonShellFile${randomInt}.py`;
+    const filePath = tmpdir() + sep + `pythonShellFile${randomInt}.py`;
     writeFileSync(filePath, code);
 
     return PythonShell.run(filePath, options);

--- a/test/test-python-shell.ts
+++ b/test/test-python-shell.ts
@@ -1,7 +1,8 @@
 import * as should from 'should';
 import { PythonShell } from '..';
 import { sep, join } from 'path';
-import { EOL as newline } from 'os';
+import { EOL as newline, tmpdir } from 'os';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { chdir, cwd } from 'process';
 
 describe('PythonShell', function () {
@@ -123,6 +124,36 @@ describe('PythonShell', function () {
   describe('#runString(script, options)', function () {
     before(() => {
       PythonShell.defaultOptions = {};
+    });
+    it('should create a temporary file in the OS temp directory before running', async function () {
+      const originalRun = PythonShell.run;
+      let capturedScriptPath = '';
+      let capturedOptions = null;
+
+      // Avoid spawning Python: we only verify temp file path generation and handoff.
+      (PythonShell as any).run = async (scriptPath, options) => {
+        capturedScriptPath = scriptPath;
+        capturedOptions = options;
+        return [];
+      };
+
+      const options = { mode: 'text' as const };
+      const code = 'print(\"hello from runString\")';
+
+      try {
+        await PythonShell.runString(code, options);
+
+        capturedScriptPath.should.startWith(tmpdir() + sep + 'pythonShellFile');
+        capturedScriptPath.should.endWith('.py');
+        existsSync(capturedScriptPath).should.be.true();
+        readFileSync(capturedScriptPath, 'utf8').should.eql(code);
+        capturedOptions.should.eql(options);
+      } finally {
+        if (capturedScriptPath && existsSync(capturedScriptPath)) {
+          unlinkSync(capturedScriptPath);
+        }
+        (PythonShell as any).run = originalRun;
+      }
     });
     it('should be able to execute a string of python code', function (done) {
       PythonShell.runString('print("hello");print("world")', null).then(


### PR DESCRIPTION
Summary
- Fix `PythonShell.runString()` temp file path generation by calling `tmpdir()` instead of using the function reference.
- Add a focused unit test that validates temp-file creation in OS temp dir and verifies handoff to `PythonShell.run` without spawning Python.

Why
- Current code builds `filePath` with `tmpdir + sep + ...`, which uses the function object instead of the temp directory path.
- This can produce invalid or non-existent paths for `writeFileSync`, making `runString()` fragile.

Test Plan
- `npm test -- --grep "temporary file in the OS temp directory"`
  - Result in this environment: `1 passing`.

Compatibility
- No API changes.
- Existing behavior is preserved; this only fixes temp-path construction and adds regression coverage.