### PR TITLE
fix: parse tracebacks after stderr prefixes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -395,13 +395,16 @@ export class PythonShell extends EventEmitter {
   private parseError(data: string | Buffer) {
     let text = '' + data;
     let error: PythonShellError;
+    const tracebackHeader = 'Traceback (most recent call last):';
+    const tracebackStart = text.indexOf(tracebackHeader);
 
-    if (/^Traceback/.test(text)) {
-      // traceback data is available
-      let lines = text.trim().split(newline);
+    if (tracebackStart >= 0) {
+      // Traceback can be prefixed by stderr logs, so parse from the traceback header.
+      const tracebackText = text.slice(tracebackStart).trim();
+      let lines = tracebackText.split(newline);
       let exception = lines.pop();
       error = new PythonShellError(exception);
-      error.traceback = data;
+      error.traceback = tracebackText;
       // extend stack trace
       error.stack +=
         newline + '    ----- Python Traceback -----' + newline + '  ';

--- a/test/python/error_with_stderr_prefix.py
+++ b/test/python/error_with_stderr_prefix.py
@@ -1,0 +1,10 @@
+import sys
+
+sys.stderr.write('prefix log before traceback\n')
+
+
+def fail():
+    raise Exception('Error sample')
+
+
+fail()

--- a/test/test-python-shell.ts
+++ b/test/test-python-shell.ts
@@ -614,6 +614,15 @@ describe('PythonShell', function () {
         done();
       });
     });
+    it('should parse traceback when stderr has prefixed logs', function (done) {
+      let pyshell = new PythonShell('error_with_stderr_prefix.py');
+      pyshell.on('pythonError', function (err) {
+        err.message.should.be.equal('Exception: Error sample');
+        err.should.have.property('traceback');
+        err.traceback.should.containEql('Traceback (most recent call last)');
+        done();
+      });
+    });
   });
 
   describe('.kill()', function () {


### PR DESCRIPTION
## Summary
- parse Python tracebacks even when stderr contains prefix log lines before the traceback header
- keep the parsed traceback focused on the traceback block
- add a regression fixture/test for prefixed stderr output

## Validation
- `npm ci`
- `npm test -- --grep "parseError|prefixed logs"` (4 passing)

Fixes #309.
