### PR TITLE
Avoid shell parsing for Python helper commands

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,8 +3,8 @@ import {
   ChildProcess,
   spawn,
   SpawnOptions,
-  exec,
-  execSync,
+  execFile,
+  execFileSync,
 } from 'child_process';
 import { EOL as newline, tmpdir } from 'os';
 import { join, sep } from 'path';
@@ -42,7 +42,7 @@ function getRandomInt() {
   return Math.floor(Math.random() * 10000000000);
 }
 
-const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
 
 export interface Options extends SpawnOptions {
   /**
@@ -334,8 +334,7 @@ export class PythonShell extends EventEmitter {
    */
   static async checkSyntaxFile(filePath: string) {
     const pythonPath = this.getPythonPath();
-    let compileCommand = `${pythonPath} -m py_compile ${filePath}`;
-    return execPromise(compileCommand);
+    return execFilePromise(pythonPath, ['-m', 'py_compile', filePath]);
   }
 
   /**
@@ -379,12 +378,12 @@ export class PythonShell extends EventEmitter {
 
   static getVersion(pythonPath?: string) {
     if (!pythonPath) pythonPath = this.getPythonPath();
-    return execPromise(pythonPath + ' --version');
+    return execFilePromise(pythonPath, ['--version']);
   }
 
   static getVersionSync(pythonPath?: string) {
     if (!pythonPath) pythonPath = this.getPythonPath();
-    return execSync(pythonPath + ' --version').toString();
+    return execFileSync(pythonPath, ['--version']).toString();
   }
 
   /**

--- a/test/test-python-shell.ts
+++ b/test/test-python-shell.ts
@@ -1,8 +1,16 @@
 import * as should from 'should';
 import { PythonShell } from '..';
 import { sep, join } from 'path';
-import { EOL as newline } from 'os';
+import { EOL as newline, tmpdir } from 'os';
 import { chdir, cwd } from 'process';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
 
 describe('PythonShell', function () {
   const pythonFolder = 'test/python';
@@ -95,6 +103,64 @@ describe('PythonShell', function () {
       PythonShell.checkSyntax('x=').catch(() => {
         done();
       });
+    });
+    it('should check syntax for files whose path contains spaces', async function () {
+      const tempDirectory = mkdtempSync(join(tmpdir(), 'python shell syntax '));
+      const filePath = join(tempDirectory, 'valid script.py');
+
+      try {
+        writeFileSync(filePath, 'x = 1\n');
+        const result = await PythonShell.checkSyntaxFile(filePath);
+        result.stderr.should.eql('');
+      } finally {
+        rmSync(tempDirectory, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('#getVersion(pythonPath)', function () {
+    function createCurrentExecutableAtSpacedPath() {
+      const tempDirectory = mkdtempSync(
+        join(tmpdir(), 'python shell version '),
+      );
+      const executablePath = join(
+        tempDirectory,
+        process.platform === 'win32' ? 'fake python.exe' : 'fake python',
+      );
+
+      try {
+        symlinkSync(process.execPath, executablePath);
+      } catch (_) {
+        copyFileSync(process.execPath, executablePath);
+        if (process.platform !== 'win32') chmodSync(executablePath, 0o755);
+      }
+
+      return { tempDirectory, executablePath };
+    }
+
+    it('should get the version when the executable path contains spaces', async function () {
+      const { tempDirectory, executablePath } =
+        createCurrentExecutableAtSpacedPath();
+
+      try {
+        const result = await PythonShell.getVersion(executablePath);
+        result.stdout.trim().should.eql(process.version);
+      } finally {
+        rmSync(tempDirectory, { recursive: true, force: true });
+      }
+    });
+
+    it('should get the version synchronously when the executable path contains spaces', function () {
+      const { tempDirectory, executablePath } =
+        createCurrentExecutableAtSpacedPath();
+
+      try {
+        PythonShell.getVersionSync(executablePath)
+          .trim()
+          .should.eql(process.version);
+      } finally {
+        rmSync(tempDirectory, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- replace shell-string execution in `checkSyntaxFile`, `getVersion`, and `getVersionSync` with argument-vector `execFile` calls
- fix paths with spaces for explicit Python executable paths and syntax-checked file paths
- add regressions for `getVersion()`, `getVersionSync()`, and `checkSyntaxFile()` paths containing spaces

Fixes #181.

## Why

The previous implementation built commands like `${pythonPath} --version`. That breaks when the Python executable path contains spaces and also leaves these helpers dependent on shell parsing. Passing the executable and arguments separately avoids quoting issues.

## Verification

- `npm test -- --grep "path contains spaces|executable path contains spaces"`
- `npm test`
- `npx prettier --check index.ts test/test-python-shell.ts`
- `git diff --check`
- `review-fix-loop`: clean, no introduced correctness/security/maintainability issues
