### PR TITLE
Guard optional stream setEncoding

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -193,6 +193,7 @@ export class PythonShell extends EventEmitter {
       self[name] = self.childProcess[name];
       self.parser &&
         self[name] &&
+        typeof self[name].setEncoding === 'function' &&
         self[name].setEncoding(options.encoding || 'utf8');
     });
 


### PR DESCRIPTION
## Summary

- only call `setEncoding` when a child-process stream exposes that method
- preserves current behavior for Node streams while avoiding the Bun/Deno-compatible stream TypeError reported in #305

Fixes #305.

## Verification

- `npm test` (rerun passed with 43 passing; one earlier local run hit three Mocha 2s timeouts before passing on rerun)
- `bun -e 'import { PythonShell } from "./index.ts"; await PythonShell.run("exit-code.py", { scriptPath: "test/python", stdio: ["ignore", "pipe", "pipe"] }); console.log("bun smoke passed");'`
- `git diff --check`
- `review-fix-loop clean`
