### PR TITLE
Use OS temp dir in runString

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -371,7 +371,7 @@ export class PythonShell extends EventEmitter {
   static runString(code: string, options?: Options) {
     // put code in temp file
     const randomInt = getRandomInt();
-    const filePath = tmpdir + sep + `pythonShellFile${randomInt}.py`;
+    const filePath = join(tmpdir(), `pythonShellFile${randomInt}.py`);
     writeFileSync(filePath, code);
 
     return PythonShell.run(filePath, options);

--- a/test/test-python-shell.ts
+++ b/test/test-python-shell.ts
@@ -1,8 +1,9 @@
 import * as should from 'should';
 import { PythonShell } from '..';
-import { sep, join } from 'path';
-import { EOL as newline } from 'os';
+import { basename, dirname, sep, join } from 'path';
+import { EOL as newline, tmpdir } from 'os';
 import { chdir, cwd } from 'process';
+import { readFileSync, unlinkSync } from 'fs';
 
 describe('PythonShell', function () {
   const pythonFolder = 'test/python';
@@ -146,6 +147,33 @@ describe('PythonShell', function () {
       );
       results.should.be.an.Array().and.have.lengthOf(2);
       results.should.eql(['hello', 'world']);
+    });
+    it('should write runString code to a temporary file', async function () {
+      const originalRun = PythonShell.run;
+      const options = { pythonPath: PythonShell.defaultPythonPath };
+      const code = 'print("hello from temp file")';
+      let capturedPath: string;
+      let capturedOptions: object;
+
+      PythonShell.run = ((scriptPath: string, runOptions: object) => {
+        capturedPath = scriptPath;
+        capturedOptions = runOptions;
+        return Promise.resolve(['ok']);
+      }) as typeof PythonShell.run;
+
+      try {
+        let results = await PythonShell.runString(code, options);
+
+        results.should.eql(['ok']);
+        dirname(capturedPath).should.eql(tmpdir());
+        basename(capturedPath).should.startWith('pythonShellFile');
+        basename(capturedPath).should.endWith('.py');
+        readFileSync(capturedPath, 'utf8').should.eql(code);
+        capturedOptions.should.equal(options);
+      } finally {
+        PythonShell.run = originalRun;
+        if (capturedPath) unlinkSync(capturedPath);
+      }
     });
     after(() => {
       PythonShell.defaultOptions = {


### PR DESCRIPTION
Refreshes stale PR #320 with the same minimal fix and focused coverage.

`PythonShell.runString()` currently builds its temp file path with the imported `tmpdir` function reference instead of calling `tmpdir()`. That can produce an invalid path before `PythonShell.run()` is reached.

This change uses `path.join(tmpdir(), ...)` and adds a regression test that intercepts `PythonShell.run()` to verify:
- the generated script path is in the OS temp directory
- the generated file contains the provided code
- the original run options are passed through unchanged

Verification:
- `npm run compileOnce && npx mocha -r ts-node/register --grep "runString"`
- `npm test`
- `npx prettier --check index.ts test/test-python-shell.ts`
- `git diff --check`
