### PR TITLE
fix: split process output on \n instead of os.EOL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -86,7 +86,7 @@ export class NewlineTransformer extends Transform {
   _transform(chunk: any, encoding: string, callback: TransformCallback) {
     let data: string = chunk.toString();
     if (this._lastLineData) data = this._lastLineData + data;
-    const lines = data.split(newline);
+    const lines = data.split(/\r?\n/);
     this._lastLineData = lines.pop();
     lines.forEach(this.push.bind(this));
     callback();

--- a/test/test-python-shell.ts
+++ b/test/test-python-shell.ts
@@ -1,5 +1,5 @@
 import * as should from 'should';
-import { PythonShell } from '..';
+import { PythonShell, NewlineTransformer } from '..';
 import { sep, join } from 'path';
 import { EOL as newline } from 'os';
 import { chdir, cwd } from 'process';
@@ -640,5 +640,27 @@ describe('PythonShell', function () {
         done();
       }, 500);
     });
+  });
+});
+
+describe('NewlineTransformer', function () {
+  function collect(input: Buffer): Promise<string[]> {
+    return new Promise((resolve) => {
+      const t = new NewlineTransformer();
+      t.setEncoding('utf8');
+      const out: string[] = [];
+      t.on('data', (chunk) => out.push(chunk.toString()));
+      t.on('end', () => resolve(out));
+      t.write(input);
+      t.end();
+    });
+  }
+
+  it('splits on \\n regardless of the platform line ending', async function () {
+    (await collect(Buffer.from('hello\nworld\n'))).should.eql(['hello', 'world']);
+  });
+
+  it('splits on \\r\\n', async function () {
+    (await collect(Buffer.from('hello\r\nworld\r\n'))).should.eql(['hello', 'world']);
   });
 });


### PR DESCRIPTION
Fixes #331.

`NewlineTransformer` split stdout/stderr on `os.EOL`. On Windows that is `\r\n`, so output using bare `\n` line endings was never split into messages: the data was buffered in `_lastLineData` and dropped, because `_flush` runs after the stream's `end` handler has already resolved the `run()`/`end()` callback. `print()` worked only because Python's text-mode stdout translates `\n` to `\r\n` on Windows.

Split on `/\r?\n/` so both line endings are handled.

Added a regression test against the exported `NewlineTransformer` (deterministic and OS independent). It fails on the previous code for the bare-`\n` case and passes with the fix.