### PR TITLE
Return kill() result

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -448,11 +448,11 @@ export class PythonShell extends EventEmitter {
 
   /**
    * Sends a kill signal to the process
-   * @returns {PythonShell} The same instance for chaining calls
+   * @returns {boolean} Whether the kill signal was sent successfully
    */
   kill(signal?: NodeJS.Signals) {
     this.terminated = this.childProcess.kill(signal);
-    return this;
+    return this.terminated;
   }
 
   /**

--- a/test/test-python-shell.ts
+++ b/test/test-python-shell.ts
@@ -617,9 +617,9 @@ describe('PythonShell', function () {
   });
 
   describe('.kill()', function () {
-    it('set terminated to correct value', function (done) {
+    it('return kill result and set terminated to correct value', function (done) {
       let pyshell = new PythonShell('infinite_loop.py');
-      pyshell.kill();
+      should(pyshell.kill()).be.true();
       pyshell.terminated.should.be.true;
       done();
     });


### PR DESCRIPTION
Fixes #255.

Summary

return the boolean result from childProcess.kill() through PythonShell.kill()

keep terminated synchronized with the same result

add regression coverage that asserts kill() returns true when the signal is sent successfully

Testing

reproduced the current bug with a focused TypeScript contract test: the existing return this behavior fails the boolean-return assertion

compiled and ran the patched contract with strict TypeScript checks; verified true, false, signal forwarding, and deprecated terminate() alias behavior

verified the unified diff applies cleanly against the exact current HEAD snippets used by index.ts and test/test-python-shell.ts

The full repository test suite was not run locally because this execution environment could not reach the npm registry. Repository CI should run the normal npm test matrix once the PR is opened.